### PR TITLE
Fastaheader reading, Memory reduction and speedup

### DIFF
--- a/IORobot.py
+++ b/IORobot.py
@@ -18,7 +18,8 @@ def obtainLength(folderName, fileName):
             if tmplen != 0:
                 lenDic[tmpName] = tmplen
                 tmplen = 0
-            tmpName = tmp[1:]
+            headerList = tmp.split();
+            tmpName = headerList[0][1:]
         else:
             tmplen += len(tmp)
         tmp = f.readline().rstrip()
@@ -29,6 +30,7 @@ def obtainLength(folderName, fileName):
     f.close()
     
     return lenDic
+    
     
 
 

--- a/alignerRobot.py
+++ b/alignerRobot.py
@@ -4,6 +4,57 @@ import houseKeeper
 from multiprocessing import Pool
 import time
 
+def extractMumDataAndRemove(folderName, fileName,lenDic,thres):
+    
+    f = open(folderName + fileName, 'r')
+    removeList = []
+    
+    for i in range(6):
+        tmp = f.readline()
+
+    while len(tmp) > 0:
+        info = tmp.split('|')
+        filterArr = info[1].split()
+        rdGpArr = info[-1].split('\t')
+        firstArr = info[0].split()
+        
+        matchLenArr = info[2].split()
+    
+        matchLen1 = int(matchLenArr[0])
+        matchLen2 = int(matchLenArr[1])    
+        percentMatch = float(info[3])
+        
+        
+        helperStart, helperEnd = int(firstArr[0]), int(firstArr[1])
+        readStart, readEnd = int(filterArr[0]) , int(filterArr[1])
+        if readStart > readEnd:
+            readEnd = int(filterArr[0])
+            readStart = int(filterArr[1])
+        
+        helperName = rdGpArr[0].rstrip().lstrip()
+        readName = rdGpArr[1].rstrip().lstrip()
+        
+        
+        if helperName != readName:
+            l1, l2 = lenDic[helperName], lenDic[readName]
+            
+            if abs(l1 - matchLen1) < thres and abs(l2 - matchLen2) > thres:
+                removeList.append(helperName)
+            elif abs(l1 - matchLen1) > thres and abs(l2 - matchLen2) < thres:
+                removeList.append(readName)
+            elif abs(l1 - matchLen1) < thres and abs(l2 - matchLen2) < thres:
+                print "Both shortembedd " +" "+ str(helperStart)+" " + str(helperEnd)+" " + str(readStart)+" " + str(readEnd)+" "+ str(matchLen1)+" " + str(matchLen2)+" " + str(percentMatch)+" "+ str(helperName)+" "+ str(readName)
+        
+        
+        #dataList.append([helperStart, helperEnd , readStart, readEnd, matchLen1, matchLen2, percentMatch, helperName, readName ])
+    
+        tmp = f.readline().rstrip()
+                
+    f.close()
+    
+    return removeList
+
+
 def extractMumData(folderName, fileName):
     # "Format of the dataList :  1      765  |    11596    10822  |      765      775  |    84.25  | ref_NC_001133_       scf7180000000702"
     f = open(folderName + fileName, 'r')

--- a/nonRedundantResolver.py
+++ b/nonRedundantResolver.py
@@ -4,7 +4,6 @@ import IORobot
 import houseKeeper
 
 # ## 0) Preprocess by removing embedded contigs (I: contigs.fasta ; O : noEmbed.fasta)
-
 def removeEmbedded(folderName , mummerLink):
     print "removeEmbedded"
     thres = 10
@@ -12,33 +11,14 @@ def removeEmbedded(folderName , mummerLink):
 
     os.system("cp " + folderName + "contigs2.fasta " + folderName + "contigs.fasta") 
 
-    if True:
+    if not os.path.isfile(folderName + "selfOut"):
         alignerRobot.useMummerAlignBatch(mummerLink, folderName, [["self", "contigs.fasta", "contigs.fasta", ""]], houseKeeper.globalParallel )
         # alignerRobot.useMummerAlign(mummerLink, folderName, "self", "contigs.fasta", "contigs.fasta")
         # outputName, referenceName, queryName, specialName
     
-    dataList = alignerRobot.extractMumData(folderName, "selfOut")
-    
-    dataList = alignerRobot.transformCoor(dataList)
-    
     lenDic = IORobot.obtainLength(folderName, 'contigs.fasta')
-    
-    removeList = []
-    for eachitem in dataList:
-        match1, match2, name1, name2 = eachitem[4], eachitem[5], eachitem[7], eachitem[8]
+    removeList = alignerRobot.extractMumDataAndRemove(folderName,"selfOut",lenDic,thres)
         
-        if name1 != name2:
-            l1, l2 = lenDic[name1], lenDic[name2]
-            
-            if abs(l1 - match1) < thres and abs(l2 - match2) > thres:
-                removeList.append(name1)
-            elif abs(l1 - match1) > thres and abs(l2 - match2) < thres:
-                removeList.append(name2)
-            elif abs(l1 - match1) < thres and abs(l2 - match2) < thres:
-                print "Both shortembedd", eachitem
-                
-    
-    
     nameList = []
     for eachitem in lenDic:
         nameList.append(eachitem)
@@ -51,4 +31,51 @@ def removeEmbedded(folderName , mummerLink):
     print len(nameList)
     
     IORobot.putListToFileO(folderName, "contigs.fasta", "noEmbed", nameList)
+
+#def removeEmbedded(folderName , mummerLink):
+#    print "removeEmbedded"
+#    thres = 10
+#    os.system("sed -e 's/|//g' " + folderName + "contigs.fasta  > " + folderName + "contigs2.fasta")
+
+#    os.system("cp " + folderName + "contigs2.fasta " + folderName + "contigs.fasta") 
+
+ #   if True:
+ #       alignerRobot.useMummerAlignBatch(mummerLink, folderName, [["self", "contigs.fasta", "contigs.fasta", ""]], houseKeeper.globalParallel )
+ #       # alignerRobot.useMummerAlign(mummerLink, folderName, "self", "contigs.fasta", "contigs.fasta")
+ #       # outputName, referenceName, queryName, specialName
+ #   
+ #   dataList = alignerRobot.extractMumData(folderName, "selfOut")
+ #   
+ #   dataList = alignerRobot.transformCoor(dataList)
+ #   
+ #   lenDic = IORobot.obtainLength(folderName, 'contigs.fasta')
+ #   
+ #   removeList = []
+ #   for eachitem in dataList:
+ #       match1, match2, name1, name2 = eachitem[4], eachitem[5], eachitem[7], eachitem[8]
+ #       
+ #       if name1 != name2:
+ #           l1, l2 = lenDic[name1], lenDic[name2]
+ #           
+ #           if abs(l1 - match1) < thres and abs(l2 - match2) > thres:
+ #               removeList.append(name1)
+ #           elif abs(l1 - match1) > thres and abs(l2 - match2) < thres:
+ #               removeList.append(name2)
+ #           elif abs(l1 - match1) < thres and abs(l2 - match2) < thres:
+ #               print "Both shortembedd", eachitem
+ #               
+ #   
+ #   
+ #   nameList = []
+ #   for eachitem in lenDic:
+ #       nameList.append(eachitem)
+#
+ #   print len(nameList)
+ #   
+ #   for eachitem in removeList:
+ #       if eachitem in nameList:
+ #           nameList.remove(eachitem)
+ #   print len(nameList)
+ #   
+ #   IORobot.putListToFileO(folderName, "contigs.fasta", "noEmbed", nameList)
 


### PR DESCRIPTION
Changed some part of the code for the first Step. Reduced the memory footprint in our case from 300GB to 2GB. Additionally it will create a speedup as no unnecessary copies are produced.
